### PR TITLE
RTCClient.disconnect() fix

### DIFF
--- a/SwiftyWebRTC/Code/RTCClient.swift
+++ b/SwiftyWebRTC/Code/RTCClient.swift
@@ -116,6 +116,8 @@ public class RTCClient: NSObject {
             peerConnection.remove(stream)
         }
         self.delegate?.rtcClient(client: self, didChangeState: .disconnected)
+
+        initialisePeerConnection()
     }
 
     public func makeOffer() {


### PR DESCRIPTION
RTCClient couldn't connect after disconnect() and startConnection() call because of broken peerConnection.

> (peerConnection.close() method) also releases any resources in use by the ICE agent
> https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close